### PR TITLE
fix: Correct TemplateSyntaxError in task_list.html

### DIFF
--- a/templates/tareas/task_list.html
+++ b/templates/tareas/task_list.html
@@ -32,7 +32,7 @@
     {% if tasks %}
         <div class="task-grid">
             {% for task in tasks %}
-            <div class="task-card {% if task.fecha_vencimiento < now.date or (task.fecha_vencimiento == now.date and task.hora_fin and task.hora_fin < now.time) %}task-overdue{% endif %}">
+            <div class="task-card {% if task.fecha_vencimiento < now.date or task.fecha_vencimiento == now.date and task.hora_fin and task.hora_fin < now.time %}task-overdue{% endif %}">
                 <div class="task-header">
                     <h3 class="task-title">
                         <a href="{% url 'task-detail' task.pk %}">{{ task.nombre }}</a>
@@ -51,7 +51,7 @@
                         <i class="fas fa-calendar-alt"></i>
                         {{ task.fecha_vencimiento|date:"d M Y" }}
                         {% if task.hora_inicio %}{{ task.hora_inicio|time:"H:i" }}{% endif %}{% if task.hora_fin %} - {{ task.hora_fin|time:"H:i" }}{% endif %}
-                        {% if task.fecha_vencimiento < now.date or (task.fecha_vencimiento == now.date and task.hora_fin and task.hora_fin < now.time) %}
+                        {% if task.fecha_vencimiento < now.date or task.fecha_vencimiento == now.date and task.hora_fin and task.hora_fin < now.time %}
                             <span class="task-due-badge overdue">¡Vencida!</span>
                         {% endif %}
                     </div>


### PR DESCRIPTION
I removed unnecessary parentheses from complex `if` conditions in `templates/tareas/task_list.html` that were causing a TemplateSyntaxError.

The overdue logic conditions for the task card class and the overdue badge were updated to:
`{% if task.fecha_vencimiento < now.date or task.fecha_vencimiento == now.date and task.hora_fin and task.hora_fin < now.time %}`